### PR TITLE
Use Dependabot to check for outdated action versions used in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+    assignees:
+      - per1234
+
+  # Configure check for outdated GitHub Actions actions in workflow templates.
+  - package-ecosystem: github-actions
+    # The workflows under the .github/workflows/ subfolder of this path will be checked.
+    directory: /workflow-templates/dependabot/workflow-template-copies/
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: (DO NOT MERGE)
+    labels:
+      - "topic: infrastructure"
+    assignees:
+      - per1234

--- a/.github/workflows/check-sync.yml
+++ b/.github/workflows/check-sync.yml
@@ -1,0 +1,32 @@
+# This repository contains intentionally duplicated copies of files:
+# - Workflow template copies under workflow-templates/dependabot/workflow-template-copies used for Dependabot checks.
+# - Workflow template copies in .github/workflows used for this repository's own CI system.
+# - Assets for the workflow templates used in this repository.
+#
+# This workflow checks that the copies are in sync.
+# If the workflow fails, run workflow-templates/etc/sync.sh and commit.
+
+name: Check File Duplicates Sync
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check file duplicates sync
+        run: |
+          SYNC_SCRIPT_PATH="workflow-templates/etc/sync.sh"
+          "${{ github.workspace }}/$SYNC_SCRIPT_PATH"
+          git add .
+          if ! git diff --color --exit-code HEAD; then
+            echo "::error::File duplicates are out of sync. Please run $SYNC_SCRIPT_PATH"
+            exit 1
+          fi

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,0 +1,33 @@
+# GitHub Actions workflow templates
+
+A collection of reusable [GitHub Actions workflows](https://docs.github.com/en/actions/quickstart#creating-your-first-workflow). These can be added to any repository under the organization via [GitHub's "Actions" web UI](https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization), but copying the files to the repository does the same thing so it's not required to use the web UI.
+
+## Documentation
+
+While some workflows can be added to any repository without any modification, others need to be configured for each project. "TODO" comments in the workflow explain what needs to be done. Documentation for each workflow is provided by the .md file of the same name, including:
+
+- Instructions
+- List of asset files which must be added to the repository along with the workflow
+- Markup for status badges that can be added to the readme
+- Stock commit messages
+- Links to related workflows
+
+## Workflow template strategy
+
+Whenever possible, these workflows should be used as the models when setting up GitHub Actions in a repository, rather than sourcing equivalent, possibly outdated, workflows from a random repository. If fixes or improvements are discovered, please push them back here to the workflow templates, from whence they can propagate to all other repositories.
+
+Addition of, or requests for, any additional workflows that can be reusable between several of Arduino's repositories are welcome.
+
+## GitHub Actions outages
+
+**Note**: GitHub Actions periodically has outages which result in workflow failures unrelated to any problems with the contents of the repository or actions used by the workflow. In this event, the workflows will start passing again once the service recovers.
+
+## Dependabot
+
+Dependabot is used to check for outdated action versions used in the workflow templates. Details about that are [here](dependabot/README.md).
+
+The same can be done for the workflows of any repository. See the instructions [here](assets/dependabot/README.md).
+
+## License
+
+Unless stated otherwise in the individual file or subfolder, the contents of this folder and subfolders are in the public domain, as defined by the [CC0 1.0 Universal license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/workflow-templates/assets/dependabot/README.md
+++ b/workflow-templates/assets/dependabot/README.md
@@ -1,0 +1,44 @@
+# Dependabot for GitHub Actions
+
+Dependabot can be used to check for outdated action versions used in the repository's GitHub Actions workflows:
+
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+
+## Instructions
+
+Just copy [this `dependabot.yml` file](dependabot.yml) to the `.github/` folder of the target repository (or add the entry if the repository already has a `/.github/dependabot.yml`) and everything else is handled automatically.
+
+### Note
+
+Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.
+
+So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. The effort needed to manually adjust the ref when this happens is trivial.
+
+Dependabot will automatically close its PR once the workflow has been updated.
+
+## Commit message
+
+```
+Configure Dependabot to check for outdated actions used in workflows
+
+Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to
+be outdated, it will submit a pull request to update them.
+
+NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1`
+to `uses: foo/bar@v2.3.4`). When the action author has provided a major version ref, use that instead
+(e.g., `uses: foo/bar@v2`). Dependabot will automatically close its PR once the workflow has been updated.
+
+More information:
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+```
+
+## PR message
+
+```Markdown
+Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.
+
+NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.
+
+More information:
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+```

--- a/workflow-templates/assets/dependabot/dependabot.yml
+++ b/workflow-templates/assets/dependabot/dependabot.yml
@@ -1,0 +1,12 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/workflow-templates/dependabot/README.md
+++ b/workflow-templates/dependabot/README.md
@@ -1,0 +1,13 @@
+# Outdated GitHub Actions action version check
+
+Dependabot is used to [check for outdated action versions](https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot) used in the workflow templates.
+
+The files under `/workflow-templates/dependabot/workflow-template-copies/.github/workflows/` are duplicates of the files under `/workflow-templates/`. This is done as a workaround for the lack of support for defining exact workflow folders in the Dependabot configuration (it always checks the YAML files in the `.github/workflows/` subfolder of the path specified via the `updates.directory` dependabot.yml configuration key.
+
+So do not merge the PRs from Dependabot for the files under `/workflow-templates/dependabot-copies/.github/workflows/`. The equivalent workflow templates directly under `/workflow-templates/` must be updated instead. The Dependabot PRs for these files are used only as notifications of available action updates.
+
+Dependabot's PRs will often try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.
+
+Dependabot will automatically close its PR once the workflow has been updated.
+
+Run `/workflow-templates/etc/sync.sh` after making any changes to the workflow templates under `/workflow-templates/`. That script will synchronize the copies. The repository has a CI workflow to check the sync.

--- a/workflow-templates/etc/sync.sh
+++ b/workflow-templates/etc/sync.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Sync the repository's intentionally duplicated files.
+
+readonly REPOSITORY_ROOT_PATH="$(git rev-parse --show-toplevel)"
+readonly WORKFLOW_TEMPLATES_PATH="${REPOSITORY_ROOT_PATH}/workflow-templates"
+readonly WORKFLOW_TEMPLATE_COPIES_PATH="${REPOSITORY_ROOT_PATH}/workflow-templates/dependabot/workflow-template-copies/.github/workflows"
+
+# Sync workflow templates with the copies in the folder where Dependabot can check them for updates.
+mkdir --parents "$WORKFLOW_TEMPLATE_COPIES_PATH"
+rm --force "${WORKFLOW_TEMPLATE_COPIES_PATH}/"*
+find "$WORKFLOW_TEMPLATES_PATH" -maxdepth 1 -type f -and \( -name '*.yml' -or -name '*.yaml' \) -exec cp '{}' "$WORKFLOW_TEMPLATE_COPIES_PATH" \;


### PR DESCRIPTION
### General Introduction
This is the first of a series of pull requests to set up [GitHub Actions workflow templates](https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization) for Arduino.

The plan is to first set up an infrastructure for automatically checking the quality of the workflows. Since these workflows will eventually be used in hundreds of repositories, it's important to make an extra effort that the templates be correctly configured and consistent. These automated checks will also assist in reviewing the proposed workflows.

### Pull Request Description

Dependabot will periodically check the GitHub Actions workflows and workflow templates of the repository and submit pull
requests to update any that are found to be using an outdated version of an action.

This check has previously been a manual process, and a frequently neglected one. Up to date action versions are
especially important in the workflow templates, since they are the source for the CI systems of many repositories.

Typically, the best approach is to only pin the major version of the action (e.g., `uses: foo/bar@v1`), so the workflow
will automatically use the latest version of the action except when there have been breaking changes. Many actions
provide major version refs for this purpose. Dependabot's PRs may propose to use a ref that pins the patch version
(e.g., `uses: foo/bar@v2.3.4`). In this case, when a major version ref is available, the Dependabot PR should be treated
as only an update notification, and the update done manually, at which time the Dependabot PR will be closed
automatically.

In the case of PRs from Dependabot for updates to the workflow template copies, these serve only as update notifications
Dependabot has been configured to prefix the PR message with "(DO NOT MERGE)" to make this clear.

I have configured Dependabot to assign me to these pull requests and will take responsibility for reviewing and testing them.

---
In addition to setting up Dependabot for this repository, I have also provided a template Dependabot configuration file and documentation to make it easy to setting this up in other repositories where the maintainers have determined it would be useful.