### PR TITLE
Remove donation links

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [arduino]
-custom: "https://www.arduino.cc/en/Main/Donate"

--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,7 @@ This organization hosts the various open-source projects managed by the Arduino 
   * [Built-in examples](https://github.com/arduino/arduino-examples)
 * GitHub Actions: [arduino-lint-action](https://github.com/arduino/arduino-lint-action) - [compile-sketches](https://github.com/arduino/compile-sketches) - [report-size-deltas](https://github.com/arduino/report-size-deltas)
 
-Maintaining these projects and handling community contributions is a hard job. Please support us by [buying original Arduino products](https://store.arduino.cc/) or by [donating](https://www.arduino.cc/en/donate/). Your help will be very appreciated.
+Maintaining these projects and handling community contributions is a hard job. Please support us by [buying original Arduino products](https://store.arduino.cc/). Your help will be very appreciated.
 
 ### ✨ How you can contribute
 


### PR DESCRIPTION
The Arduino company is no longer soliciting monetary donations. For this reason, the donation link is hereby removed from the organization profile, and from the "Sponsor this project" section of each repository homepage (as was previously configured via the FUNDING.yml file).

Community members who wish to contribute to the project still have opportunities to do so via the other options listed in the organization profile.