### PR TITLE
Remove FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [arduino]
-custom: "https://www.arduino.cc/en/Main/Donate"


### PR DESCRIPTION
This file is used to specify options for providing monetary support for the organization's projects. The data from the file is used to populate the "Sponsor this project" section of the repository home page for any repository in which the "Sponsorships" option is enabled:

<img width="409" height="249" alt="image" src="https://github.com/user-attachments/assets/03768253-a81a-4563-9c76-588431cbb030" />

The Arduino company is no longer soliciting monetary donations. For this reason, the donation page on the Arduino website has been deleted. This means the funding link specified by this file no longer works

Community members who wish to contribute to the project still have opportunities to do so via [the options listed in the organization profile](https://github.com/arduino#user-content--how-you-can-contribute).

---

Related: https://github.com/arduino/.github/pull/3, https://github.com/arduino/.github/commit/84a39bb23b0ac6d491269f30e53f85d390948f55